### PR TITLE
Remove focus ring of all focusable elements

### DIFF
--- a/outline.js
+++ b/outline.js
@@ -22,7 +22,7 @@
 
 	// Using mousedown instead of mouseover, so that previously focused elements don't lose focus ring on mouse move
 	add_event_listener('mousedown', function(){
-		set_css('a{outline:none}');
+		set_css(':focus{outline:0}::-moz-focus-inner{border:0;}');
 	});
 
 	add_event_listener('keydown', function(){


### PR DESCRIPTION
Other elements can have focus ring, especially buttons on Chrome
