### PR TITLE
Remove `box-shadow` as well as `outline`

### DIFF
--- a/outline.js
+++ b/outline.js
@@ -21,7 +21,7 @@
 
 	// Using mousedown instead of mouseover, so that previously focused elements don't lose focus ring on mouse move
 	add_event_listener('mousedown', function(){
-		set_css(':focus{outline:0}::-moz-focus-inner{border:0;}');
+		set_css(':focus{outline:0;box-shadow: none;}::-moz-focus-inner{border:0;}');
 	});
 
 	add_event_listener('keydown', function(){

--- a/outline.js
+++ b/outline.js
@@ -21,7 +21,7 @@
 
 	// Using mousedown instead of mouseover, so that previously focused elements don't lose focus ring on mouse move
 	add_event_listener('mousedown', function(){
-		set_css(':focus{outline:0 !important;box-shadow: none !important;}:focus-within{outline:0 !important;box-shadow: none !important;}::-moz-focus-inner{border:0 !important;}');
+		set_css(':focus{outline:0 !important;box-shadow: none !important;}:focus-within{outline:0 !important;box-shadow: none !important;}::-moz-focus-inner{border:0 !important;}input:focus~label[class*="focused-label"]{outline:0 !important;box-shadow:none !important;');
 	});
 
 	add_event_listener('keydown', function(){

--- a/outline.js
+++ b/outline.js
@@ -21,7 +21,7 @@
 
 	// Using mousedown instead of mouseover, so that previously focused elements don't lose focus ring on mouse move
 	add_event_listener('mousedown', function(){
-		set_css(':focus{outline:0;box-shadow: none;}::-moz-focus-inner{border:0;}');
+		set_css(':focus{outline:0 !important;box-shadow: none !important;}::-moz-focus-inner{border:0 !important;}');
 	});
 
 	add_event_listener('keydown', function(){

--- a/outline.js
+++ b/outline.js
@@ -21,7 +21,7 @@
 
 	// Using mousedown instead of mouseover, so that previously focused elements don't lose focus ring on mouse move
 	add_event_listener('mousedown', function(){
-		set_css(':focus{outline:0 !important;box-shadow: none !important;}::-moz-focus-inner{border:0 !important;}');
+		set_css(':focus{outline:0 !important;box-shadow: none !important;}:focus-within{outline:0 !important;box-shadow: none !important;}::-moz-focus-inner{border:0 !important;}');
 	});
 
 	add_event_listener('keydown', function(){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remove-focus-outline",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Removes CSS outlines in an accessible manner",
   "main": "outline.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remove-focus-outline",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Removes CSS outlines in an accessible manner",
   "main": "outline.js",
   "scripts": {


### PR DESCRIPTION
Hi @lindsayevans , here's a quick PR to reset the `box-shadow` as well as `outline`.

This is useful for users who use `box-shadow` to apply a focus ring instead of outline, Bootstrap 4 does this for example, and it's useful if you want a focus ring to follow the `border-radius` of the focusable element.

However, this might cause unintended consequences for some people who have box-shadows on elements such as buttons, so I'll understand completely if you chose not to reset this property for that reason.

For users who want this behaviour, you can load my fork from JSDelivr:

`https://cdn.jsdelivr.net/gh/philwolstenholme/outline.js@master/outline.min.js`